### PR TITLE
Fix some type instabilities and add CI

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}  # optional
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
+        os: [ubuntu-latest, windows-latest, macOS-latest] 
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /Manifest.toml
 /dev/
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,13 @@ authors = ["Reinier Doelman <rdoelman@users.noreply.github.com>"]
 version = "0.1.0"
 
 [deps]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+
+[targets]
+test = ["Test"]

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -69,22 +69,22 @@ Stacktrace:
 ```
 """
 function mn2Noll(m::Int,n::Int)
-  if n < abs(m) || isodd(n-m)
-    throw(ArgumentError("Invalid combination of (m,n)=($m,$n) in Noll indexing."))
-  else
-    if m > 0 && (mod(n,4) ∈ (0,1))
-      p = 0
-    elseif m < 0 && (mod(n,4) ∈ (2,3))
-      p = 0
-    elseif m ≥ 0 && (mod(n,4) ∈ (2,3))
-      p = 1
-    elseif m ≤ 0 && (mod(n,4) ∈ (0,1))
-      p = 1
-    else
+    if n < abs(m) || isodd(n-m)
         throw(ArgumentError("Invalid combination of (m,n)=($m,$n) in Noll indexing."))
+    else
+        if m > 0 && (mod(n,4) ∈ (0,1))
+            p = 0
+        elseif m < 0 && (mod(n,4) ∈ (2,3))
+            p = 0
+        elseif m ≥ 0 && (mod(n,4) ∈ (2,3))
+            p = 1
+        elseif m ≤ 0 && (mod(n,4) ∈ (0,1))
+            p = 1
+        else
+            throw(ArgumentError("Invalid combination of (m,n)=($m,$n) in Noll indexing."))
+        end
+        return Int((1//2)*n*(n+1) + abs(m) + p)
     end
-    return Int((1//2)*n*(n+1) + abs(m) + p)
-  end
 end
 
 """
@@ -114,9 +114,9 @@ julia> [OSA2mn(j) for j in 0:10]
 ```
 """
 function OSA2mn(j::Int)
-  n = Int(ceil((-3 + sqrt(9+8j))/2))
-  m = 2j-n*(n+2)
-  return (Int(m),Int(n))
+    n = Int(ceil((-3 + sqrt(9+8j))/2))
+    m = 2j-n*(n+2)
+    return (Int(m),Int(n))
 end
 
 """
@@ -134,26 +134,26 @@ julia> [OSA2mn(j) for j in 0:10]
 ```
 """
 function Noll2mn(j::Int)
-  n = Int(ceil((-3 + sqrt(1+8j))/2))
-  jr = j - Int(n*(n+1)/2)
-  if mod(n,4) ∈ (0,1)
-    m1 = jr
-    m2 = -(jr-1)
-    if iseven(n-m1)
-      m = m1
-    else
-      m = m2
+    n = Int(ceil((-3 + sqrt(1+8j))/2))
+    jr = j - Int(n*(n+1)/2)
+    if mod(n,4) ∈ (0,1)
+        m1 = jr
+        m2 = -(jr-1)
+        if iseven(n-m1)
+            m = m1
+        else
+            m = m2
+        end
+    else # mod(n,4) ∈ (2,3)
+        m1 = jr-1
+        m2 = -(jr)
+        if iseven(n-m1)
+            m = m1
+        else
+            m = m2
+        end
     end
-  else # mod(n,4) ∈ (2,3)
-    m1 = jr-1
-    m2 = -(jr)
-    if iseven(n-m1)
-      m = m1
-    else
-      m = m2
-    end
-  end
-  return (m,n)
+    return (m,n)
 end
 
 """
@@ -169,7 +169,7 @@ julia> [Noll2OSA(OSA2Noll(j)) for j = 0:10]
 ```
 """
 function Noll2OSA(j::Int)
-  return mn2OSA(Noll2mn(j)...)
+    return mn2OSA(Noll2mn(j)...)
 end
 
 """
@@ -185,7 +185,7 @@ julia> [Noll2OSA(OSA2Noll(j)...) for j = 0:10]
 ```
 """
 function OSA2Noll(j::Int)
-  return mn2Noll(OSA2mn(j)...)
+    return mn2Noll(OSA2mn(j)...)
 end
 
 
@@ -223,7 +223,7 @@ function normalization(::Type{T}, m::Int, n::Int) where T
 end
 
 function normalization(m::Int,n::Int) # normalization constant of the zernike polynomial
-  return normalization(Float64, m, n)
+    return normalization(Float64, m, n)
 end
 
 """
@@ -282,13 +282,13 @@ julia> Z(0.5,0.2)
 ```
 """
 function Zernike(j::Int;index=:OSA,coord=:polar)
-  if index == :OSA
-    return Zernike(OSA2mn(j)...,coord=coord)
-  elseif index == :Noll
-    return Zernike(Noll2mn(j)...,coord=coord)
-  else
-    error("Unknown Zernike sequential index")
-  end
+    if index == :OSA
+        return Zernike(OSA2mn(j)...,coord=coord)
+    elseif index == :Noll
+        return Zernike(Noll2mn(j)...,coord=coord)
+    else
+        error("Unknown Zernike sequential index")
+    end
 end
 
 """
@@ -299,13 +299,13 @@ The Zernike polynomials used are specified with an index vector J, according to 
 
 """
 function Zernikecoefficients(phase::AbstractArray{T,2}, J::Vector{Int}; index=:OSA) where T
-  s = size(phase)
-  X = range(-one(T), stop=one(T), length=s[1])
-  Y = range(-one(T), stop=one(T), length=s[2])
-
-  D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in Y] for j in J ]
-  G = cat([D[i][:] for i in 1:length(J)]...; dims=2)
-  return G \ view(phase, :)
+    s = size(phase)
+    X = range(-one(T), stop=one(T), length=s[1])
+    Y = range(-one(T), stop=one(T), length=s[2])
+    
+    D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in Y] for j in J ]
+    G = cat([D[i][:] for i in 1:length(J)]...; dims=2)
+    return G \ view(phase, :)
 end
 
 """
@@ -316,15 +316,15 @@ The Zernike polynomials used are specified with an index vector J, according to 
 
 """
 function Zernikecoefficients(X::AbstractArray{<: AbstractFloat,1}, phase::AbstractArray{Float64,2}, J::Vector{Int}; index=:OSA)
-  s = size(phase)
-  if !(s[1] == s[2] && s[1] == length(X))
-    error("Non-matching size")
-  end
-
-  D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in X] for j in J ]
-
-  G = cat([D[i][:] for i in 1:length(J)]...; dims=2)
-  return G \ view(phase, :)
+    s = size(phase)
+    if !(s[1] == s[2] && s[1] == length(X))
+        error("Non-matching size")
+    end
+    
+    D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in X] for j in J ]
+    
+    G = cat([D[i][:] for i in 1:length(J)]...; dims=2)
+    return G \ view(phase, :)
 end
 
 """
@@ -373,11 +373,11 @@ function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Vector{Int},
 end
 
 function evaluateZernike(n::Int, J::Int, coefficients::T; index=:OSA) where T
-  return evaluateZernike(n, [J], [coefficients]; index=index)
+    return evaluateZernike(n, [J], [coefficients]; index=index)
 end
 
 function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Int, coefficients::T; index=:OSA) where T
-  return evaluateZernike(X, [J], [coefficients]; index=index)
+    return evaluateZernike(X, [J], [coefficients]; index=index)
 end
 
 end # module

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -37,7 +37,6 @@ Stacktrace:
 """
 function mn2OSA(m::Int,n::Int)
     if n < abs(m) || isodd(n-m)
-        # throw an error instead of NaN because of type instability
         throw(ArgumentError("Invalid combination of (m,n)=($m,$n) in OSA/ANSI indexing.")) 
     else
         return Int((1//2)*(n*(n+2)+m))

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -339,11 +339,17 @@ julia> W = evaluateZernike(64,[5, 6],[0.3, 4.1])
 ```
 """
 function evaluateZernike(N::Int, J::Vector{Int}, coefficients::AbstractArray{T,1}; index=:OSA) where T
-  X = range(-one(T), stop=one(T), length=N)
-  Y = range(-one(T), stop=one(T), length=N)
+    X = range(-one(T), stop=one(T), length=N)
+    Y = range(-one(T), stop=one(T), length=N)'
 
-  D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in Y] for j in J ]
-  return reduce(+,map(*,D,coefficients))
+    out_arr = zeros(T, N, N) 
+
+    for j = 1:length(J)
+        Z = Zernike(J[j], coord=:cartesian, index=index)
+        out_arr .+= coefficients[j] .* Z.(X, Y)
+    end
+
+    return out_arr
 end
 
 """

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -204,7 +204,7 @@ function R(::Type{T}, m::Int,n::Int) where T
     p(s) = ((-1)^s * factorial(n-s)) / T(factorial(s) * factorial(Int(0.5 * (n+abs(m)) - s)) 
                                         * factorial(Int(0.5 * (n-abs(m)) - s)))
     # round brackets to be a generator instead of a Vector 
-    f(x) = sum((p(s) * x .^ (n-2s) for s in 0:Int((n-abs(m))/2)))
+    f(x) = sum(p(s) * x .^ (n-2s) for s in 0:Int((n-abs(m))/2))
     return f
 end
 
@@ -243,7 +243,7 @@ julia> Z(0.5,0.2)
 ```
 """
 function Zernike(m::Int, n::Int; coord=:polar)
-    δ(ρ) = eltype(ρ)(abs(ρ) <= 1)
+    δ(ρ) = ifelse(abs(ρ) ≤ 1, one(eltype(ρ)), zero(eltype(ρ)))
     
     # use let block to prevent this bug https://github.com/JuliaLang/julia/issues/15276
     # further, we pass the types to normalization
@@ -323,6 +323,7 @@ function Zernikecoefficients(X::AbstractArray{<: AbstractFloat,1}, phase::Abstra
   end
 
   D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in X] for j in J ]
+
   G = cat([D[i][:] for i in 1:length(J)]...; dims=2)
   return G \ view(phase, :)
 end

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -155,8 +155,9 @@ function OSA2Noll(j::Int)
   return mn2Noll(OSA2mn(j)...)
 end
 
+
 """
-    R(m::Int,n::Int)
+    R([T=Float64], m::Int,n::Int)
 
 Obtain the function ρ -> R_n^|m|(ρ), where R is the radial polynomial in Zernike polynomials
 
@@ -165,10 +166,14 @@ Obtain the function ρ -> R_n^|m|(ρ), where R is the radial polynomial in Zerni
 julia> R(1,1)
 ```
 """
-function R(m::Int,n::Int) # radial polynomial
+function R(::Type{T}, m::Int,n::Int) where T
   p = s -> ((-1)^s * factorial(n-s))/ (factorial(s)*factorial(Int(0.5*(n+abs(m))-s))*factorial(Int(0.5*(n-abs(m))-s)))
   f = x -> sum([p(s)*x.^(n-2s) for s in 0:Int((n-abs(m))/2)])
   return f
+end
+
+function R(m::Int,n::Int) # radial polynomial
+    R(Float64, m, n)
 end
 
 function normalization(m::Int,n::Int) # normalization constant of the zernike polynomial
@@ -244,12 +249,12 @@ The Zernike polynomials used are specified with an index vector J, according to 
 """
 function Zernikecoefficients(phase::AbstractArray{T,2}, J::Vector{Int}; index=:OSA) where T
   s = size(phase)
-  X = range(-1.,stop=1,length=s[1])
-  Y = range(-1.,stop=1,length=s[2])
+  X = range(-one(T), stop=one(T), length=s[1])
+  Y = range(-one(T), stop=one(T), length=s[2])
 
   D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in Y] for j in J ]
   G = cat([D[i][:] for i in 1:length(J)]...; dims=2)
-  return G\phase[:]
+  return G \ view(phase, :)
 end
 
 """
@@ -267,7 +272,7 @@ function Zernikecoefficients(X::AbstractArray{<: AbstractFloat,1}, phase::Abstra
 
   D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in X] for j in J ]
   G = cat([D[i][:] for i in 1:length(J)]...; dims=2)
-  return G\phase[:]
+  return G \ view(phase, :)
 end
 
 """
@@ -281,8 +286,8 @@ julia> W = evaluateZernike(64,[5, 6],[0.3, 4.1])
 ```
 """
 function evaluateZernike(N::Int, J::Vector{Int}, coefficients::AbstractArray{T,1}; index=:OSA) where T
-  X = range(-1.,stop=1,length=N)
-  Y = range(-1.,stop=1,length=N)
+  X = range(-one(T), stop=one(T), length=N)
+  Y = range(-one(T), stop=one(T), length=N)
 
   D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in Y] for j in J ]
   return reduce(+,map(*,D,coefficients))

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -245,11 +245,15 @@ julia> Z(0.5,0.2)
 function Zernike(m::Int, n::Int; coord=:polar)
     δ(ρ) = eltype(ρ)(abs(ρ) <= 1)
     
+    # use let block to prevent this bug https://github.com/JuliaLang/julia/issues/15276
+    # further, we pass the types to normalization
     Z = let 
         if m ≥ 0
-            (ρ, θ) ->   normalization(eltype(ρ), m,n) * R(eltype(ρ), m, n)(ρ) * cos(m*θ) * δ(ρ)
+            (ρ, θ) -> (  normalization(promote_type(eltype(ρ), eltype(θ)), m,n) 
+                       * R(eltype(ρ), m, n)(ρ) * cos(m*θ) * δ(ρ))
         else
-            (ρ, θ) -> - normalization(eltype(ρ), m,n) * R(eltype(ρ), m, n)(ρ) * sin(m*θ) * δ(ρ)
+            (ρ, θ) -> (- normalization(promote_type(eltype(ρ), eltype(θ)), m,n)
+                       * R(eltype(ρ), m, n)(ρ) * sin(m*θ) * δ(ρ))
         end
     end
 

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -242,7 +242,7 @@ Compute the Zernike coefficients (OSA normalization) that in a least-squares sen
 The Zernike polynomials used are specified with an index vector J, according to OSA indexing.
 
 """
-function Zernikecoefficients(phase::AbstractArray{Float64,2}, J::Vector{Int}; index=:OSA)
+function Zernikecoefficients(phase::AbstractArray{T,2}, J::Vector{Int}; index=:OSA) where T
   s = size(phase)
   X = range(-1.,stop=1,length=s[1])
   Y = range(-1.,stop=1,length=s[2])
@@ -280,7 +280,7 @@ Evaluate the Zernike polynomials on an N-by-N grid as specified by the Zernike c
 julia> W = evaluateZernike(64,[5, 6],[0.3, 4.1])
 ```
 """
-function evaluateZernike(N::Int, J::Vector{Int}, coefficients::AbstractArray{Float64,1}; index=:OSA)
+function evaluateZernike(N::Int, J::Vector{Int}, coefficients::AbstractArray{T,1}; index=:OSA) where T
   X = range(-1.,stop=1,length=N)
   Y = range(-1.,stop=1,length=N)
 
@@ -298,16 +298,17 @@ Evaluate the Zernike polynomials on a grid as specified by the Zernike coefficie
 julia> W = evaluateZernike(64,[5, 6],[0.3, 4.1])
 ```
 """
-function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Vector{Int}, coefficients::Vector{Float64}; index=:OSA)
+function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Vector{Int},
+                         coefficients::Vector{T}; index=:OSA) where T
   D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in X] for j in J ]
   return reduce(+,map(*,D,coefficients))
 end
 
-function evaluateZernike(n::Int, J::Int, coefficients::Float64; index=:OSA)
+function evaluateZernike(n::Int, J::Int, coefficients::T; index=:OSA) where T
   return evaluateZernike(n, [J], [coefficients]; index=index)
 end
 
-function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Int, coefficients::Float64; index=:OSA)
+function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Int, coefficients::T; index=:OSA) where T
   return evaluateZernike(X, [J], [coefficients]; index=index)
 end
 

--- a/src/ZernikePolynomials.jl
+++ b/src/ZernikePolynomials.jl
@@ -343,7 +343,6 @@ function evaluateZernike(N::Int, J::Vector{Int}, coefficients::AbstractArray{T,1
     Y = range(-one(T), stop=one(T), length=N)'
 
     out_arr = zeros(T, N, N) 
-
     for j = 1:length(J)
         Z = Zernike(J[j], coord=:cartesian, index=index)
         out_arr .+= coefficients[j] .* Z.(X, Y)
@@ -364,8 +363,14 @@ julia> W = evaluateZernike(64,[5, 6],[0.3, 4.1])
 """
 function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Vector{Int},
                          coefficients::Vector{T}; index=:OSA) where T
-  D = [[Zernike(j,coord=:cartesian,index=index)(x,y) for x in X, y in X] for j in J ]
-  return reduce(+,map(*,D,coefficients))
+    N = length(X)
+    out_arr = zeros(T, N, N) 
+    for j = 1:length(J)
+        Z = Zernike(J[j], coord=:cartesian, index=index)
+        out_arr .+= coefficients[j] .* Z.(X, X')
+    end
+    
+    return out_arr
 end
 
 function evaluateZernike(n::Int, J::Int, coefficients::T; index=:OSA) where T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,24 @@ using Test
         @test all([mn2OSA(OSA2mn(i)...) for i in 0:30] .== collect(0:30))
         @test all([mn2Noll(Noll2mn(i)...) for i in 1:31] .== collect(1:31))
     end
+    
+    @testset "Type stability" begin
+        Z = Zernike(4,4,coord=:cartesian)
+        @test Z(0.2, 0.1) ≈ -0.002213594362117866
+        @test Z(0.2f0, 0.1f0) ≈ -0.0022135945f0 
+        @test typeof(Z(0.2f0, 0.1f0)) == Float32 
+        @test typeof(Z(0.2, 0.1)) == Float64 
+
+        @test typeof(ZernikePolynomials.R(Float32, 1,1)(1)) == Float32 
+        @test typeof(ZernikePolynomials.R(Float32, 1,1)(1.0)) == Float64
+        @test typeof(ZernikePolynomials.R(Float64, 1,1)(1.0)) == Float64
+        @test typeof(ZernikePolynomials.R(Float64, 1,1)(1.0f0)) == Float64
+        @test typeof(ZernikePolynomials.R(1,1)(1.0)) == Float64
+
+        @test typeof(normalization(Float32, 1,1)) == Float32
+        @test typeof(normalization(ComplexF32, 1,1)) == ComplexF32
+        @test typeof(normalization(1,1)) == Float64 
+    end
 
     @testset "Generation of Zernike polynomials" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,12 +6,12 @@ using Test
     @testset "Sequential index conversion" begin
         @test mn2Noll(0,0) == 1
         @test mn2Noll(-1,3) == 7
-        @test isnan(mn2Noll(-1,0))
+        @test_throws ArgumentError mn2Noll(-1,0)
         @test mn2Noll(3,5) == 18
 
         @test mn2OSA(0,0) == 0
         @test mn2OSA(-1,3) == 7
-        @test isnan(mn2OSA(-1,0))
+        @test_throws ArgumentError mn2OSA(-1,0)
         @test mn2OSA(3,5) == 19
 
         @test all([mn2OSA(OSA2mn(i)...) for i in 0:30] .== collect(0:30))


### PR DESCRIPTION
Hi!

I tried to fix some of the type preserving issues. Also, I worked on fixing a few Julia related performance bugs.
That improved performance quite a bit:

Current state:
```julia
julia> using ZernikePolynomials

julia> x = randn((2000,));

julia> y = x';

julia> using BenchmarkTools

julia> @btime Zernike(10, coord=:cartesian, index=:OSA).($x,$y);
  605.860 ms (16000026 allocations: 457.76 MiB)

# before it returned Float64
Zernike(10, coord=:cartesian, index=:OSA).(0.5f0, 0.5f0)
-6.911376921754665e-8
```

New state:
```julia
julia> using ZernikePolynomials
[ Info: Precompiling ZernikePolynomials [e462d300-c971-11e9-30f1-fb93b1f8f73a]

julia> x = randn((2000,));

julia> y = x';

julia> using BenchmarkTools

julia> @btime Zernike(10, coord=:cartesian, index=:OSA).($x,$y);
  165.865 ms (6 allocations: 30.52 MiB)

# now a Float32
julia> Zernike(10, coord=:cartesian, index=:OSA).(0.5f0, 0.5f0)
-6.911377f-8
```

Another change was to throw errors for invalid index combinations. In one `if-else` branch you returned an `Int` in the other one a `NaN` which is a `Float64` type. That's a type instability which I think is better solved by throwing an error.

Also improved `evaluateZernike` a little:
```julia
# OLD
julia> @btime ϕ = evaluateZernike(256, 2, 0.54, index=:OSA);
  4.940 ms (393231 allocations: 11.00 MiB)

julia> x = randn((100,)); 

julia> @btime ϕ = evaluateZernike(x, 2, 0.54, index=:OSA);

  816.550 μs (60015 allocations: 1.68 MiB)


# THIS PR
julia> @btime ϕ = evaluateZernike(256, 2, 0.54, index=:OSA);
 2.263 ms (15 allocations: 513.14 KiB)

julia> x = randn((100,));

julia> @btime ϕ = evaluateZernike(x, 2, 0.54, index=:OSA);
  328.311 μs (14 allocations: 78.69 KiB)

```



I would be happy to incorporate your feedback!

Best,

Felix