### PR TITLE
Use index types to number polynomials

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,13 @@
 name = "ZernikePolynomials"
 uuid = "e462d300-c971-11e9-30f1-fb93b1f8f73a"
 authors = ["Reinier Doelman <rdoelman@users.noreply.github.com>"]
-version = "0.1.0"
-
-[deps]
+version = "0.1.1"
 
 [compat]
 julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
 
 [targets]
 test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -8,49 +8,69 @@ It features the following:
 - functions to estimate Zernike coefficients in a least squares sense from a user-provided input.
 
 ## Conversion to and between (Noll & OSA/ANSI) sequential indices
+
 This package provides conversion utility functions between three common ways of specifying a Zernike polynomial.
+Numbering conventions are implemented as subtypes of the abstract type `ZernikeIndex`.
 
-The first is a tuple (m,n) of integers to specify the polynomial Z_n^m(ρ,θ), where n ≥ m, and (ρ,θ) are polar coordinates (radius and angle).
+The first is to use `NM(n, m)` to specify the polynomial `Zₙᵐ(ρ,θ)`, where `n` and `m` are integers with `n ≥ abs(m)` (further, `n - abs(m)` must be even), and `(ρ,θ)` are polar coordinates (radius and angle).
 
-The second (sequential) index is the OSA/ANSI standard index (0,1,2,3,...).
+The second (sequential) index is the OSA/ANSI standard index (0,1,2,3,...), specified as `OSA(j)`.
 
-The third is Noll's sequential index (1,2,3,...).
+The third is Noll's sequential index (1,2,3,...), specified as `Noll(j)`.
 
-An invalid combination (m,n) returns NaN in conversion.
+Invalid inputs to the `ZernikeIndex` constructors result in an `ArgumentError`, which ensures that you can only construct valid indexes. You can convert between types by calling the constructor or using `convert`:
 
 ```julia-repl
->> using ZernikePolynomials
->> [mn2OSA(n,m) for n in 0:4, m in -5:5]
->> [mn2Noll(n,m) for n in 0:4, m in -5:5]
->> [OSA2mn(j) for j in 0:5]
->> [Noll2mn(j) for j in 0:5]
->> [Noll2OSA(OSA2Noll(j)) for j = 0:5]
+julia> using ZernikePolynomials
+
+julia> nm = NM(3, -3)
+NM(3, -3)
+
+julia> OSA(nm)
+OSA(6)
+
+julia> Noll(nm)
+Noll(9)
+
+julia> NM(OSA(6))
+NM(3, -3)
+
+julia> [NM(n, m) for n in 0:4, m in -5:5]
+ERROR: ArgumentError: Invalid Zernike index pair (n,m)=(0,-5).
+...
+
+julia> Noll(0)
+ERROR: ArgumentError: Invalid Noll index 0.
+...
+
+julia> supertype(NM)
+ZernikeIndex
 ```
 
 ## Evaluating Zernike polynomials
-The Zernike polynomials (ρ,θ) -> Z_n^m(ρ,θ) or (x,y) -> Z_n^m(x,y) can be obtained as a function as follows:
+The Zernike polynomials `(ρ,θ) -> Zₙᵐ(ρ,θ)` or `(x,y) -> Zₙᵐ(x,y)` can be obtained as a function as follows:
 
 ```julia-repl
->> Zernike(1,1)
->> Zernike(1,1,coord=:polar)
->> Z = Zernike(5,index=:Noll,coord=:cartesian) # 5th polynomial by Noll's numbering
->> Z = Zernike(1,1,coord=:cartesian)
+>> zernike(NM(1,1))
+>> zernike(NM(1,1),coord=:polar)
+>> Z = zernike(Noll(5),coord=:cartesian) # 5th polynomial by Noll's numbering
+>> Z = zernike(NM(1,1),coord=:cartesian)
 >> Z(0.5,0.2) # evaluate the function at cartesian coordinate (0.5,0.2)
 ```
 
 Polar coordinates are used by default. The functions return 0 for ρ > 1.
 
-Zernike polynomials and affine combination thereof can easily be evaluated on a grid of points using the function `evaluateZernike()`.
+Zernike polynomials and affine combination thereof can easily be evaluated on a grid of points using the function `evaluatezernike()`.
 
 For example, to evaluate 0.5*Z_2 + 0.3*Z_3 (by OSA numbering) on a 256x256 grid, use the following
 ```julia-repl
->> evaluateZernike(256, [2, 3], [0.5, 0.3], index=:OSA)
+>> evaluatezernike(256, OSA.([2, 3]), [0.5, 0.3])
 ```
 
 To evaluate it on a (square) grid with predefined coordinates, use for example
 ```julia-repl
 >> x = LinRange(-2,2,256)
->> ϕ = evaluateZernike(x, [2, 3], [0.5, 0.3], index=:OSA)
+>> ϕ = evaluatezernike(x, OSA.([2, 3]), [0.5, 0.3])
 >> using Plots
 >> heatmap(ϕ)
 ```
@@ -58,11 +78,13 @@ Here the range ``x`` is a range that gives the x and y coordinates.
 
 ### Zernike polynomial normalization
 The Zernike polynomials are normalized according to Thibos et al. - "Standards for Reporting the Optical Aberrations of Eyes", i.e.
-N_n^m = sqrt(2 (n+1) / (1 + δ(m,0)))
-where δ(m,0) = 1 for m = 0 and 0 otherwise.
+$$
+N_n^m = \sqrt{2 (n+1) / (1 + δ(m,0))}
+$$
+where $δ(m,0) = 1$ for $m = 0$ and 0 otherwise.
 These normalization constants can be obtained by `normalization(m,n)`:
 ```julia-repl
->> [normalization(OSA2mn(i)...) for i in 0:5]
+>> [normalization(NM(OSA(i))) for i in 0:5]
 ```
 Note that the definition on the [Wikipedia page on Zernike polynomials](https://en.wikipedia.org/wiki/Zernike_polynomials) is different. Here the polynomials are normalized between [-1,1].
 When using or reporting (estimated) Zernike coefficients, it is important to be aware of which normalization has been used.
@@ -71,18 +93,18 @@ When using or reporting (estimated) Zernike coefficients, it is important to be 
 A common use for Zernike polynomials is to approximate a given 2D input.
 Since Zernike polynomials are often used in optics to approximate a 2D phase, this is the term used in the function documentation.
 
-The function ``Zernikecoefficients()`` estimates (in a least-squares sense) the optimal coefficients for a sum of Zernike polynomials. A vector of (sequential) indices should be provided to specify which coefficients should be estimated
+The function `zernikecoefficients()` estimates (in a least-squares sense) the optimal coefficients for a sum of Zernike polynomials. A vector of (sequential) indices should be provided to specify which coefficients should be estimated
 
 ```julia-repl
->> ϕ = evaluateZernike(256, [2, 3], [0.5, 0.3], index=:OSA)
->> Zernikecoefficients(ϕ, [2, 3]) # ≈ [0.5, 0.3]
+>> ϕ = evaluatezernike(256, OSA.([2, 3]), [0.5, 0.3])
+>> zernikecoefficients(ϕ, OSA.([2, 3])) # ≈ [0.5, 0.3]
 ```
 
 It is also possible to specify on which coordinates the phase is defined:
 ```julia-repl
 >> x = LinRange(-2,2,256)
->> ϕ = evaluateZernike(x, [2, 3], [0.5, 0.3], index=:Noll)
->> Zernikecoefficients(x, ϕ, [1, 3], index=:Noll) # ≈ [0.0, 0.3]
+>> ϕ = evaluatezernike(x, Noll.([2, 3]), [0.5, 0.3])
+>> zernikecoefficients(x, ϕ, Noll.([1, 3])) # ≈ [0.0, 0.3]
 ```
 Note that in this last example the coefficient for the Zernike polynomial with Noll index 1 is estimated, but this is not present in ϕ. Therefore the estimated coefficient is 0.
 
@@ -92,7 +114,7 @@ using Plots
 using ZernikePolynomials
 
 x = LinRange(-1,1,256)
-ϕ = evaluateZernike(x, [2, 3], [0.5, 0.3], index=:Noll)
+ϕ = evaluatezernike(x, Noll.([2, 3]), [0.5, 0.3])
 f(x,y) = (x^2 + y^2) <= 1 ? 1. : NaN # NaNs are not plotted
 heatmap( ϕ .* [f(X,Y) for X in x, Y in x])
 ```

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,84 @@
+export mn2OSA, mn2Noll, OSA2mn, Noll2mn, OSA2Noll, Noll2OSA
+
+function makeindex(caller, j; index=:OSA)
+    Base.depwarn("$caller no longer supports (j; index=:OSA) pairs. Use the `ZernikeIndex` types instead, e.g., `OSA(j)`.", caller)
+    if index === :OSA
+        return isa(j, Integer) ? OSA(j) : OSA.(j)
+    elseif index === :Noll
+        return isa(j, Integer) ? Noll(j) : Noll.(j)
+    else
+        throw(ArgumentError("Unknown Zernike sequential index $index."))
+    end
+end
+
+function mn2OSA(m::Integer,n::Integer)
+    Base.depwarn("mn2OSA(m, n) is deprecated. Use the `ZernikeIndex` types instead, e.g., `OSA(NM(n, m))`. Note that `n` comes before `m`.", :mn2OSA)
+    return OSA(NM(n, m)).j
+end
+function mn2Noll(m::Integer,n::Integer)
+    Base.depwarn("mn2Noll(m, n) is deprecated. Use the `ZernikeIndex` types instead, e.g., `Noll(NM(n, m))`. Note that `n` comes before `m`.", :mn2Noll)
+    return Noll(NM(n, m)).j
+end
+function OSA2mn(j::Int)
+    Base.depwarn("OSA2mn(j) is deprecated. Use the `ZernikeIndex` types instead, e.g., `NM(OSA(j))`.", :OSA2mn)
+    nm = NM(OSA(j))
+    return nm.m, nm.n
+end
+function Noll2mn(j::Int)
+    Base.depwarn("Noll2mn(j) is deprecated. Use the `ZernikeIndex` types instead, e.g., `NM(Noll(j))`.", :Noll2mn)
+    nm = NM(Noll(j))
+    return nm.m, nm.n
+end
+function OSA2Noll(j::Int)
+    Base.depwarn("OSA2Noll(j) is deprecated. Use the `ZernikeIndex` types instead, e.g., `Noll(OSA(j))`.", :OSA2Noll)
+    return Noll(OSA(j)).j
+end
+function Noll2OSA(j::Int)
+    Base.depwarn("Noll2OSA(j) is deprecated. Use the `ZernikeIndex` types instead, e.g., `OSA(Noll(j))`.", :Noll2OSA)
+    return OSA(Noll(j)).j
+end
+
+@deprecate normalization(T::Type, m::Int, n::Int) normalization(T, NM(n, m))
+@deprecate normalization(m::Int, n::Int) normalization(NM(n, m))
+
+
+@deprecate Zernike(m::Int, n::Int; coord=:polar) zernike(NM(n, m); coord=coord)
+Zernike(j::Int; index=:OSA, coord=:polar) = zernike(makeindex(:Zernike, j; index=index); coord=coord)
+@deprecate Zernike(zi::ZernikeIndex; coord=:polar) zernike(zi; coord=coord)  # this covers the change in capitalization
+
+
+function Zernikecoefficients(phase::AbstractArray{T,2}, J::Vector{Int}; index=:OSA) where T
+    J = makeindex(:Zernikecoefficients, J; index=index)
+    return zernikecoefficients(phase, J)
+end
+function Zernikecoefficients(X::AbstractArray{<: AbstractFloat,1}, phase::AbstractArray{Float64,2}, J::Vector{Int}; index=:OSA)
+    J = makeindex(:Zernikecoefficients, J; index=index)
+    return zernikecoefficients(X, phase, J)
+end
+@deprecate Zernikecoefficients(args...; kwargs...) zernikecoefficients(args...; kwargs...)  # cover change in capitalization
+
+
+function evaluateZernike(N::Int, J::Vector{Int}, coefficients::AbstractArray{T,1}; index=:OSA) where T
+    J = makeindex(:evaluateZernike, J; index=index)
+    return evaluatezernike(N, J, coefficients)
+end
+function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Vector{Int},
+    coefficients::Vector{T}; index=:OSA) where T
+    J = makeindex(:evaluateZernike, J; index=index)
+    return evaluatezernike(X, J, coefficients)
+end
+function evaluateZernike(n::Int, J::Int, coefficients::T; index=:OSA) where T
+    J = makeindex(:evaluateZernike, J; index=index)
+    return evaluatezernike(n, J, coefficients)
+end
+function evaluateZernike(X::AbstractArray{<: AbstractFloat,1}, J::Int, coefficients::T; index=:OSA) where T
+    J = makeindex(:evaluateZernike, J; index=index)
+    return evaluatezernike(X, J, coefficients)
+end
+
+@deprecate evaluateZernike(args...; kwargs...) evaluatezernike(args...; kwargs...)  # cover change in capitalization
+
+
+# This is used in tests but was not exported
+@deprecate R(m::Int, n::Int) R(NM(n, m))
+@deprecate R(T::Type, m::Int, n::Int) R(T, NM(n, m))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,16 +16,18 @@ using Test
 
         @test all([mn2OSA(OSA2mn(i)...) for i in 0:30] .== collect(0:30))
         @test all([mn2Noll(Noll2mn(i)...) for i in 1:31] .== collect(1:31))
+
+        @test convert(NM, OSA(6)) === NM(OSA(6)) === NM(3, -3)
     end
-    
+
     @testset "Type stability" begin
         Z = Zernike(4,4,coord=:cartesian)
         @test Z(0.2, 0.1) ≈ -0.002213594362117866
-        @test Z(0.2f0, 0.1f0) ≈ -0.0022135945f0 
-        @test typeof(Z(0.2f0, 0.1f0)) == Float32 
-        @test typeof(Z(0.2, 0.1)) == Float64 
+        @test Z(0.2f0, 0.1f0) ≈ -0.0022135945f0
+        @test typeof(Z(0.2f0, 0.1f0)) == Float32
+        @test typeof(Z(0.2, 0.1)) == Float64
 
-        @test typeof(ZernikePolynomials.R(Float32, 1,1)(1)) == Float32 
+        @test typeof(ZernikePolynomials.R(Float32, 1,1)(1)) == Float32
         @test typeof(ZernikePolynomials.R(Float32, 1,1)(1.0)) == Float64
         @test typeof(ZernikePolynomials.R(Float64, 1,1)(1.0)) == Float64
         @test typeof(ZernikePolynomials.R(Float64, 1,1)(1.0f0)) == Float64
@@ -33,7 +35,7 @@ using Test
 
         @test typeof(normalization(Float32, 1,1)) == Float32
         @test typeof(normalization(ComplexF32, 1,1)) == ComplexF32
-        @test typeof(normalization(1,1)) == Float64 
+        @test typeof(normalization(1,1)) == Float64
     end
 
     @testset "Generation of Zernike polynomials" begin


### PR DESCRIPTION
This is a substantial API change, although it is not a
breaking change as the old API is still supported via
deprecations. The concept is to use three types, `NM`,
`OSA`, and `Noll`, to specify the numbering
convention. The constructor of each checks for
validity, so it is impossible to construct invalid index
values. Then, instead of passing in both an `::Int` and
an `index ∈ (:OSA, :Noll)` to lots of functions, the
package functions are simply implemented in terms
of their preferred index type, and other index types
are supported by conversion.

The advantages of this design are:
- index validity is guaranteed and only has to be checked in one place
- indices are "self-documenting" about how they should be interpreted (unlike an `Int`).
- using functions named `x2y` for conversion means that if you have `n` different indexing conventions, you need `n^2-n` (quadratic in `n`) exported names. But if you use types, you only need `n` exported names (linear in `n`).

This also enhances flexibility, e.g., on `master` specifying `J = 0:9` for `Zernikecoefficients` results in an error because that function only takes a `Vector{Int}`. It also adopts the conventions of the [Julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/) regarding capitalization of names.

Finally, to ensure I didn't make breaking changes, I deliberately left the tests the way they were: my editor cleaned up some extraneous spaces, and I added one `convert` test, but all the old tests still pass. If you like this and want to merge it, in a separate PR I will:
1. move the old tests to a `test/deprecated.jl` file
2. create their modern analogs using the new API

Some day you can release v0.2 (or v1.0?) of this package, at which point you can strip out all the old deprecations. But having them in place should provide very useful hints for people about how to migrate over to the new API.

CC @jona125